### PR TITLE
Support MoE per-expert finalize input scales

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.cu
@@ -715,6 +715,13 @@ __device__ __forceinline__ int32_t getExpertIdx(KernelParams const& params, int3
     return expertIndexes[expandedIdx];
 }
 
+template <typename KernelParams>
+__device__ __forceinline__ int32_t getPackedExpertIdxRaw(KernelParams const& params, int32_t expandedIdx)
+{
+    auto const* packedExpertIndexes = static_cast<int32_t const*>(params.expertIndexes);
+    return packedExpertIndexes[expandedIdx];
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename KernelParams>
@@ -755,6 +762,26 @@ __global__ void finalizeKernel(KernelParams params)
                 int const inIdx = permutedIdx * params.hiddenDimPadded + hiddenIdx;
                 int const inScaleIdx = expertIdx * params.hiddenDim + hiddenIdx;
                 float const inputScale = params.inScalePtr ? params.inScalePtr[inScaleIdx] : 1.0f;
+                if (params.inScalePtr != nullptr && tokenIdx == 0 && hiddenIdx < 4)
+                {
+                    if (params.expertIndexesArePacked)
+                    {
+                        int32_t const packedRaw = getPackedExpertIdxRaw(params, expandedIdx);
+                        int32_t const high16
+                            = static_cast<int16_t>((static_cast<uint32_t>(packedRaw) >> 16) & 0xffffU);
+                        int32_t const low16 = static_cast<int16_t>(static_cast<uint32_t>(packedRaw) & 0xffffU);
+                        printf("[MoE DBG] finalize scalar scale: token=%d k=%d expanded=%d permuted=%d expert=%d "
+                               "packed_raw=%d high16=%d low16=%d hidden=%d scale_idx=%d scale=%f\n",
+                            tokenIdx, k, expandedIdx, permutedIdx, expertIdx, packedRaw, high16, low16, hiddenIdx,
+                            inScaleIdx, inputScale);
+                    }
+                    else
+                    {
+                        printf("[MoE DBG] finalize scalar scale: token=%d k=%d expanded=%d permuted=%d expert=%d "
+                               "hidden=%d scale_idx=%d scale=%f\n",
+                            tokenIdx, k, expandedIdx, permutedIdx, expertIdx, hiddenIdx, inScaleIdx, inputScale);
+                    }
+                }
 
                 if (params.expertWeightsPtr != nullptr)
                 {
@@ -854,6 +881,27 @@ __global__ void finalizeKernelVecLoad(KernelParams params)
                     int const inScaleIdx = expertIdx * params.hiddenDim + hiddenIdx;
                     expertResult[idx] *= params.inScalePtr[inScaleIdx];
                 }
+                if (tokenIdx == 0 && elemIndex == 0)
+                {
+                    if (params.expertIndexesArePacked)
+                    {
+                        int32_t const packedRaw = getPackedExpertIdxRaw(params, expandedIdx);
+                        int32_t const high16
+                            = static_cast<int16_t>((static_cast<uint32_t>(packedRaw) >> 16) & 0xffffU);
+                        int32_t const low16 = static_cast<int16_t>(static_cast<uint32_t>(packedRaw) & 0xffffU);
+                        printf("[MoE DBG] finalize vec scale: token=%lld k=%d expanded=%d permuted=%d expert=%d "
+                               "packed_raw=%d high16=%d low16=%d hidden=0 scale_idx=%d scale=%f\n",
+                            static_cast<long long>(tokenIdx), k, expandedIdx, permutedIdx, expertIdx, packedRaw,
+                            high16, low16, expertIdx * params.hiddenDim, params.inScalePtr[expertIdx * params.hiddenDim]);
+                    }
+                    else
+                    {
+                        printf("[MoE DBG] finalize vec scale: token=%lld k=%d expanded=%d permuted=%d expert=%d "
+                               "hidden=0 scale_idx=%d scale=%f\n",
+                            static_cast<long long>(tokenIdx), k, expandedIdx, permutedIdx, expertIdx,
+                            expertIdx * params.hiddenDim, params.inScalePtr[expertIdx * params.hiddenDim]);
+                    }
+                }
             }
 
             threadOutput = threadOutput + scale * expertResult;
@@ -908,6 +956,27 @@ __global__ void finalizeDeepSeekKernel(KernelParams params)
                 int const inIdx = permutedIdx * params.hiddenDimPadded + hiddenIdx;
                 int const inScaleIdx = expertIdx * params.hiddenDim + hiddenIdx;
                 float const inputScale = params.inScalePtr ? params.inScalePtr[inScaleIdx] : 1.0f;
+                if (params.inScalePtr != nullptr && tokenIdx == 0 && hiddenIdx < 4)
+                {
+                    if (params.expertIndexesArePacked)
+                    {
+                        int32_t const packedRaw = getPackedExpertIdxRaw(params, expandedIdx);
+                        int32_t const high16
+                            = static_cast<int16_t>((static_cast<uint32_t>(packedRaw) >> 16) & 0xffffU);
+                        int32_t const low16 = static_cast<int16_t>(static_cast<uint32_t>(packedRaw) & 0xffffU);
+                        printf("[MoE DBG] finalize deepseek scale: token=%d k=%d expanded=%d permuted=%d expert=%d "
+                               "packed_raw=%d high16=%d low16=%d hidden=%d scale_idx=%d scale=%f block_scale=%f\n",
+                            tokenIdx, k, expandedIdx, permutedIdx, expertIdx, packedRaw, high16, low16, hiddenIdx,
+                            inScaleIdx, inputScale, blockScale);
+                    }
+                    else
+                    {
+                        printf("[MoE DBG] finalize deepseek scale: token=%d k=%d expanded=%d permuted=%d expert=%d "
+                               "hidden=%d scale_idx=%d scale=%f block_scale=%f\n",
+                            tokenIdx, k, expandedIdx, permutedIdx, expertIdx, hiddenIdx, inScaleIdx, inputScale,
+                            blockScale);
+                    }
+                }
 
                 float const expertProb = (float) params.expertWeightsPtr[tokenIdx * params.topK + k];
 

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include "DevKernel.h"
+#include "RoutingKernel.h"
 
 #include "cutlass/array.h"
 #include "cutlass/numeric_conversion.h"
@@ -701,6 +702,22 @@ namespace tg = batchedGemm::trtllm::gen;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename KernelParams>
+__device__ __forceinline__ int32_t getExpertIdx(KernelParams const& params, int32_t expandedIdx)
+{
+    if (params.expertIndexesArePacked)
+    {
+        using TypeExpW = typename KernelParams::TypeExpW;
+        auto const* packedExpertIndexes
+            = static_cast<routing::PackedScoreIdx<TypeExpW> const*>(params.expertIndexes);
+        return static_cast<int32_t>(packedExpertIndexes[expandedIdx].idx);
+    }
+    auto const* expertIndexes = static_cast<int32_t const*>(params.expertIndexes);
+    return expertIndexes[expandedIdx];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
 __global__ void finalizeKernel(KernelParams params)
 {
     using Type = typename KernelParams::Type;
@@ -734,15 +751,19 @@ __global__ void finalizeKernel(KernelParams params)
                 {
                     continue;
                 }
+                int const expertIdx = params.inScalePtr ? getExpertIdx(params, expandedIdx) : 0;
+                int const inIdx = permutedIdx * params.hiddenDimPadded + hiddenIdx;
+                int const inScaleIdx = expertIdx * params.hiddenDim + hiddenIdx;
+                float const inputScale = params.inScalePtr ? params.inScalePtr[inScaleIdx] : 1.0f;
 
                 if (params.expertWeightsPtr != nullptr)
                 {
                     TypeExpW const scale = params.expertWeightsPtr[expandedIdx];
-                    data += float{scale} * float{params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]};
+                    data += inputScale * float{scale} * float{params.inPtr[inIdx]};
                 }
                 else
                 {
-                    data += float{params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]};
+                    data += inputScale * float{params.inPtr[inIdx]};
                 }
             }
 
@@ -814,6 +835,7 @@ __global__ void finalizeKernelVecLoad(KernelParams params)
             {
                 continue;
             }
+            int const expertIdx = params.inScalePtr ? getExpertIdx(params, expandedIdx) : 0;
 
             float const scale
                 = (params.expertWeightsPtr != nullptr) ? static_cast<float>(params.expertWeightsPtr[expandedIdx]) : 1.f;
@@ -823,6 +845,16 @@ __global__ void finalizeKernelVecLoad(KernelParams params)
             float4 input = vectorizedLoadPtx(reinterpret_cast<float4 const*>(&inputPermutedPtr[elemIndex]));
             InputElem inputPermutedElem = *reinterpret_cast<InputElem const*>(&input);
             ComputeElem expertResult = arrayConvert<InputElem, ComputeElem>(inputPermutedElem);
+            if (params.inScalePtr != nullptr)
+            {
+#pragma unroll
+                for (int idx = 0; idx < FINALIZE_ELEM_PER_THREAD; ++idx)
+                {
+                    int const hiddenIdx = elemIndex * FINALIZE_ELEM_PER_THREAD + idx;
+                    int const inScaleIdx = expertIdx * params.hiddenDim + hiddenIdx;
+                    expertResult[idx] *= params.inScalePtr[inScaleIdx];
+                }
+            }
 
             threadOutput = threadOutput + scale * expertResult;
         }
@@ -872,11 +904,15 @@ __global__ void finalizeDeepSeekKernel(KernelParams params)
                 int const totalNumPaddedTokens = params.totalNumPaddedTokens[0];
                 int const scaleIdx = permutedIdx + totalNumPaddedTokens * (hiddenIdx / 128);
                 float const blockScale = params.inDqSfsPtr ? params.inDqSfsPtr[scaleIdx] : 1;
+                int const expertIdx = params.inScalePtr ? getExpertIdx(params, expandedIdx) : 0;
+                int const inIdx = permutedIdx * params.hiddenDimPadded + hiddenIdx;
+                int const inScaleIdx = expertIdx * params.hiddenDim + hiddenIdx;
+                float const inputScale = params.inScalePtr ? params.inScalePtr[inScaleIdx] : 1.0f;
 
                 float const expertProb = (float) params.expertWeightsPtr[tokenIdx * params.topK + k];
 
-                float const scale = expertProb * blockScale;
-                acc += scale * static_cast<float>(params.inPtr[permutedIdx * params.hiddenDimPadded + hiddenIdx]);
+                float const scale = inputScale * expertProb * blockScale;
+                acc += scale * static_cast<float>(params.inPtr[inIdx]);
             }
 
             // The largest (finite) value that can be represented using E4m3.
@@ -909,6 +945,11 @@ __global__ void finalizeDeepSeekKernel(KernelParams params)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void run(Data const& data, void* stream)
 {
+    if (data.inScalePtr != nullptr)
+    {
+        TLLM_CHECK_WITH_INFO(data.expertIndexes != nullptr, "Finalize input scales require expert indexes.");
+    }
+
     if (data.mUseDeepSeekFp8)
     {
         int const numThreads = 128;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -547,9 +547,12 @@ struct Data
     void* outPtr;
     float* inDqSfsPtr = nullptr;
     float* outDqSfsPtr = nullptr;
+    float const* inScalePtr = nullptr;
 
     void* expertWeightsPtr;
     int32_t* expandedIdxToPermutedIdx;
+    void const* expertIndexes = nullptr;
+    bool expertIndexesArePacked = false;
 
     int32_t numTokens;
     int32_t numExperts;
@@ -574,8 +577,11 @@ struct KernelParams
 
     float* inDqSfsPtr = nullptr;
     float* outDqSfsPtr = nullptr;
+    float const* inScalePtr = nullptr;
 
     int32_t* expandedIdxToPermutedIdx;
+    void const* expertIndexes = nullptr;
+    bool expertIndexesArePacked = false;
 
     int32_t hiddenDim;
     int32_t hiddenDimPadded;
@@ -594,8 +600,11 @@ struct KernelParams
         params.outPtr = (Type*) data.outPtr;
         params.inDqSfsPtr = data.inDqSfsPtr;
         params.outDqSfsPtr = data.outDqSfsPtr;
+        params.inScalePtr = data.inScalePtr;
 
         params.expandedIdxToPermutedIdx = data.expandedIdxToPermutedIdx;
+        params.expertIndexes = data.expertIndexes;
+        params.expertIndexesArePacked = data.expertIndexesArePacked;
 
         params.hiddenDim = data.hiddenDim;
         params.hiddenDimPadded = data.hiddenDimPadded;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -506,6 +506,10 @@ __device__ void routingPermutation(KernelParams params, PackedScoreIdx<BaseType>
         {
             params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
         }
+        if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+        {
+            params.mPtrExpandedIdxToExpertIdx[expandedIdx] = expertIdx;
+        }
         if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert)
         {
             params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
@@ -926,6 +930,10 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
             if (params.mPtrExpandedIdxToPermutedIdx != nullptr)
             {
                 params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
+            }
+            if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+            {
+                params.mPtrExpandedIdxToExpertIdx[expandedIdx] = expertIdx;
             }
             if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert)
             {

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,9 @@ struct DataBase
     // optional: if `nullptr`, it is not filled
     // dim: [mNumTokens * mTopK]
     int32_t* mPtrExpandedIdxToPermutedIdx{nullptr};
+    // optional: if `nullptr`, it is not filled
+    // dim: [mNumTokens * mTopK]
+    int32_t* mPtrExpandedIdxToExpertIdx{nullptr};
     // optional: if `nullptr`, it is not filled
     // dim: [mTileTokensDim * mTopK + (mNumExperts × mTileTokensDim) - mNumExperts]
     int32_t* mPtrPermutedIdxToExpandedIdx{nullptr};
@@ -123,6 +126,7 @@ struct KernelParamsBase
     int32_t* mPtrExpertCounts = nullptr;
     int32_t* mPtrPermutedIdxSize = nullptr;
     int32_t* mPtrExpandedIdxToPermutedIdx = nullptr;
+    int32_t* mPtrExpandedIdxToExpertIdx = nullptr;
     int32_t* mPtrPermutedIdxToExpandedIdx = nullptr;
     int32_t* mPtrPermutedIdxToTokenIdx = nullptr;
     int32_t* mPtrCtaIdxXyToBatchIdx = nullptr;
@@ -149,6 +153,7 @@ struct KernelParamsBase
         mPtrExpertCounts = data.mPtrExpertCounts;
         mPtrPermutedIdxSize = data.mPtrPermutedIdxSize;
         mPtrExpandedIdxToPermutedIdx = data.mPtrExpandedIdxToPermutedIdx;
+        mPtrExpandedIdxToExpertIdx = data.mPtrExpandedIdxToExpertIdx;
         mPtrPermutedIdxToExpandedIdx = data.mPtrPermutedIdxToExpandedIdx;
         mPtrPermutedIdxToTokenIdx = data.mPtrPermutedIdxToTokenIdx;
         mPtrCtaIdxXyToBatchIdx = data.mPtrCtaIdxXyToBatchIdx;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingLlama4.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingLlama4.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -347,6 +347,10 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
             if (params.mPtrExpandedIdxToPermutedIdx != nullptr && isTokenRouted)
             {
                 params.mPtrExpandedIdxToPermutedIdx[tokenIdx] = permutedIdx;
+            }
+            if (params.mPtrExpandedIdxToExpertIdx != nullptr && isTokenRouted)
+            {
+                params.mPtrExpandedIdxToExpertIdx[tokenIdx] = expertIdx;
             }
             // write out `mPtrPermutedIdxToExpandedIdx` if required
             if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert)

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routingDeepSeek/launchCoopKernel.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routingDeepSeek/launchCoopKernel.cu
@@ -243,6 +243,10 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts) routingIndicesCoo
         {
             params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
         }
+        if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+        {
+            params.mPtrExpandedIdxToExpertIdx[expandedIdx] = expertIdx;
+        }
         if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocalExpert)
         {
             params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routingRenormalize/launchBlockKernel.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routingRenormalize/launchBlockKernel.cu
@@ -84,6 +84,10 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
                 else
                 {
                     params.mPtrExpandedIdxToPermutedIdx[warpIdx * params.mTopK + laneIdx] = int32_t{-1};
+                    if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+                    {
+                        params.mPtrExpandedIdxToExpertIdx[warpIdx * params.mTopK + laneIdx] = int32_t{-1};
+                    }
                 }
             }
         }
@@ -266,6 +270,10 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
                 {
                     params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
                 }
+                if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+                {
+                    params.mPtrExpandedIdxToExpertIdx[expandedIdx] = expert;
+                }
                 if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocal)
                 {
                     params.mPtrPermutedIdxToExpandedIdx[permutedIdx] = expandedIdx;
@@ -417,6 +425,10 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params)
                 else
                 {
                     params.mPtrExpandedIdxToPermutedIdx[tokenIdx * params.mTopK + laneIdx] = int32_t{-1};
+                    if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+                    {
+                        params.mPtrExpandedIdxToExpertIdx[tokenIdx * params.mTopK + laneIdx] = int32_t{-1};
+                    }
                 }
             }
         }
@@ -626,6 +638,10 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params)
                     if (params.mPtrExpandedIdxToPermutedIdx != nullptr)
                     {
                         params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
+                    }
+                    if (params.mPtrExpandedIdxToExpertIdx != nullptr)
+                    {
+                        params.mPtrExpandedIdxToExpertIdx[expandedIdx] = expert;
                     }
                     if (params.mPtrPermutedIdxToExpandedIdx != nullptr && isLocal)
                     {

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
@@ -21,6 +21,8 @@
 #include "tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/KernelRunner.h"
 #include "tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/trtllmGen_bmm_export/trtllm/gen/DtypeDecl.h"
 #include "tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/trtllmGen_bmm_export/trtllm/gen/SfLayoutDecl.h"
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
 #include <iostream>
 #include <tensorrt_llm/common/assert.h>
 #include <tensorrt_llm/common/envUtils.h>
@@ -587,6 +589,124 @@ int64_t Runner::getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize, int
     return std::distance(mPassingConfigs.begin(), it);
 }
 
+namespace
+{
+
+// Print the first `count` elements of a device buffer, converting to float for display.
+// Supported dtypes: E4m3, Bfloat16, Fp16, Fp32.  Falls back to raw uint8 hex for others.
+void printDeviceTensor(char const* label, void const* devPtr, int count, btg::Dtype dtype, cudaStream_t stream)
+{
+    if (!devPtr)
+    {
+        printf("[MoE DBG] %s: nullptr\n", label);
+        return;
+    }
+    int bytesPerElem = 1;
+    switch (dtype)
+    {
+    case btg::Dtype::E4m3:
+    case btg::Dtype::E5m2:
+    case btg::Dtype::Int8:
+    case btg::Dtype::UInt8: bytesPerElem = 1; break;
+    case btg::Dtype::Bfloat16:
+    case btg::Dtype::Fp16: bytesPerElem = 2; break;
+    case btg::Dtype::Fp32:
+    case btg::Dtype::Int32: bytesPerElem = 4; break;
+    default: bytesPerElem = 1; break;
+    }
+    size_t bytes = static_cast<size_t>(count) * bytesPerElem;
+    std::vector<uint8_t> host(bytes);
+    cudaStreamSynchronize(stream);
+    cudaMemcpy(host.data(), devPtr, bytes, cudaMemcpyDeviceToHost);
+
+    printf("[MoE DBG] %s (first %d elems):", label, count);
+    for (int i = 0; i < count; ++i)
+    {
+        float val = 0.f;
+        switch (dtype)
+        {
+        case btg::Dtype::E4m3:
+        {
+            __nv_fp8_e4m3 fp8val;
+            memcpy(&fp8val, host.data() + i, 1);
+            val = static_cast<float>(fp8val);
+            break;
+        }
+        case btg::Dtype::E5m2:
+        {
+            __nv_fp8_e5m2 fp8val;
+            memcpy(&fp8val, host.data() + i, 1);
+            val = static_cast<float>(fp8val);
+            break;
+        }
+        case btg::Dtype::Bfloat16:
+        {
+            __nv_bfloat16 bf16val;
+            memcpy(&bf16val, host.data() + i * 2, 2);
+            val = __bfloat162float(bf16val);
+            break;
+        }
+        case btg::Dtype::Fp16:
+        {
+            __half hval;
+            memcpy(&hval, host.data() + i * 2, 2);
+            val = __half2float(hval);
+            break;
+        }
+        case btg::Dtype::Fp32: memcpy(&val, host.data() + i * 4, 4); break;
+        case btg::Dtype::Int32:
+        {
+            int32_t intVal;
+            memcpy(&intVal, host.data() + i * 4, 4);
+            val = static_cast<float>(intVal);
+            break;
+        }
+        default: val = static_cast<float>(host[i]); break;
+        }
+        printf(" %.4f", val);
+    }
+    printf("\n");
+}
+
+void printDeviceFloats(char const* label, float const* devPtr, int count, cudaStream_t stream)
+{
+    if (!devPtr)
+    {
+        printf("[MoE DBG] %s: nullptr\n", label);
+        return;
+    }
+    printDeviceTensor(label, devPtr, count, btg::Dtype::Fp32, stream);
+}
+
+void printDeviceInts(char const* label, int32_t const* devPtr, int count, cudaStream_t stream)
+{
+    printDeviceTensor(label, devPtr, count, btg::Dtype::Int32, stream);
+}
+
+void printPackedRoutingExpertIds(char const* label, int32_t const* devPtr, int count, cudaStream_t stream)
+{
+    if (!devPtr)
+    {
+        printf("[MoE DBG] %s: nullptr\n", label);
+        return;
+    }
+    std::vector<int32_t> host(count);
+    cudaStreamSynchronize(stream);
+    cudaMemcpy(host.data(), devPtr, static_cast<size_t>(count) * sizeof(int32_t), cudaMemcpyDeviceToHost);
+
+    printf("[MoE DBG] %s (first %d raw/high16/low16):", label, count);
+    for (int i = 0; i < count; ++i)
+    {
+        int32_t const raw = host[i];
+        int32_t const high16 = static_cast<int16_t>((static_cast<uint32_t>(raw) >> 16) & 0xffffU);
+        int32_t const low16 = static_cast<int16_t>(static_cast<uint32_t>(raw) & 0xffffU);
+        printf(" raw=%d high16=%d low16=%d", raw, high16, low16);
+    }
+    printf("\n");
+}
+
+} // namespace
+
 void Runner::run(
     MoERunnerArgs const& args, MoEWorkspace const& workspace, int device, cudaStream_t stream, int64_t configIndex)
 {
@@ -601,6 +721,18 @@ void Runner::run(
 
     auto const& config = mPassingConfigs[configIndex];
 
+    bool const dbg = (std::getenv("TLLM_MOE_DBG_TENSORS") != nullptr);
+
+    if (dbg)
+    {
+        printDeviceTensor("hidden_states (input)", args.hidden_states, 16, args.mDtypeElt, stream);
+        printDeviceFloats("hidden_states_scale (input)", static_cast<float const*>(hidden_states_scale_linear), 16, stream);
+        printDeviceFloats("finalize_input_scale (input)", args.finalize_input_scale, 16, stream);
+        printDeviceInts("topk_ids (input)", args.topk_ids, 16, stream);
+        printPackedRoutingExpertIds(
+            "routing_expert_indexes packed (after routing)", workspace.routing_expert_indexes, 16, stream);
+    }
+
     mPermuteGemm1.run(args.hidden_states, hidden_states_scale_linear, args.gemm1_weights, args.gemm1_weights_scale,
         workspace.expert_weights, args.output1_scales_scalar, args.output1_scales_gate_scalar, args.gemm1_bias,
         args.gemm1_alpha, args.gemm1_beta, args.gemm1_clamp_limit, workspace.gemm1_output, workspace.gemm1_output_scale,
@@ -610,6 +742,12 @@ void Runner::run(
         args.mUseRoutingScalesOnInput, device, stream, config.gemm1Config,
         args.valid_hidden_size.value_or(args.hidden_size),
         args.valid_intermediate_size.value_or(args.intermediate_size));
+
+    if (dbg)
+    {
+        printDeviceTensor("gemm1_output (post-PermuteGemm1)", workspace.gemm1_output, 16, args.mDtypeElt, stream);
+        printDeviceFloats("gemm1_output_scale (post-PermuteGemm1)", workspace.gemm1_output_scale, 16, stream);
+    }
 
     // We do not fuse activation with FC1 for DeepSeek FP8 due to the weights shuffling constraint.
     void* gemm2_input = workspace.gemm1_output;
@@ -621,6 +759,12 @@ void Runner::run(
         moe::dev::activation::run(activationData, stream);
         gemm2_input = workspace.activation_output;
         gemm2_input_scale = workspace.activation_output_scale;
+
+        if (dbg)
+        {
+            printDeviceTensor("activation_output (post-activation)", workspace.activation_output, 16, args.mDtypeElt, stream);
+            printDeviceFloats("activation_output_scale (post-activation)", workspace.activation_output_scale, 16, stream);
+        }
     }
 
     // Run gemm2
@@ -632,6 +776,12 @@ void Runner::run(
         config.gemm2Config, args.valid_hidden_size.value_or(args.hidden_size),
         args.valid_intermediate_size.value_or(args.intermediate_size));
 
+    if (dbg)
+    {
+        printDeviceTensor("gemm2_output (post-Gemm2)", workspace.gemm2_output, 16, args.mDtypeOut, stream);
+        printDeviceFloats("gemm2_output_scale (post-Gemm2)", workspace.gemm2_output_scale, 16, stream);
+    }
+
     // Run finalize
     if (args.do_finalize)
     {
@@ -640,6 +790,12 @@ void Runner::run(
             "Finalize input scale factors require routing expert indexes.");
         moe::dev::finalize::run(finalizeData, stream);
         sync_check_cuda_error(stream);
+
+        if (dbg)
+        {
+            printDeviceTensor("output (post-finalize)", args.output, 16, args.mDtypeOut, stream);
+            printDeviceFloats("output_scale (post-finalize)", args.output_scale, 16, stream);
+        }
     }
 }
 } // namespace MoE

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -510,6 +510,7 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
         finalizeData.outPtr = args.output;
         finalizeData.inDqSfsPtr = workspace.gemm2_output_scale;
         finalizeData.outDqSfsPtr = args.output_scale;
+        finalizeData.inScalePtr = args.finalize_input_scale;
         if (args.mUseRoutingScalesOnInput)
         {
             finalizeData.expertWeightsPtr = nullptr;
@@ -519,6 +520,8 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
             finalizeData.expertWeightsPtr = workspace.expert_weights;
         }
         finalizeData.expandedIdxToPermutedIdx = workspace.expanded_idx_to_permuted_idx;
+        finalizeData.expertIndexes = args.topk_ids != nullptr ? args.topk_ids : workspace.routing_expert_indexes;
+        finalizeData.expertIndexesArePacked = args.topk_ids == nullptr;
         finalizeData.numTokens = args.num_tokens;
         finalizeData.numExperts = args.num_experts;
         finalizeData.topK = args.top_k;
@@ -633,6 +636,8 @@ void Runner::run(
     if (args.do_finalize)
     {
         // Run finalize
+        TLLM_CHECK_WITH_INFO(args.finalize_input_scale == nullptr || workspace.routing_expert_indexes != nullptr,
+            "Finalize input scale factors require routing expert indexes.");
         moe::dev::finalize::run(finalizeData, stream);
         sync_check_cuda_error(stream);
     }

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
@@ -66,10 +66,10 @@ Runner::Runner(int32_t tileTokensDim)
 void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts, int32_t topK,
     int32_t nGroup, int32_t topkGroup, int32_t localExpertOffset, int32_t localNumExperts, float routedScalingFactor,
     int32_t* routingExpertIndexes, int32_t* expertCountHistogram, int32_t* permutedIdxSize,
-    int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx, int32_t* permutedIdxToTokenIdx,
-    void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx,
-    int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas, btg::Dtype dtypeElt, bool useRoutingScalesOnInput,
-    bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream)
+    int32_t* expandedIdxToPermutedIdx, int32_t* expandedIdxToExpertIdx, int32_t* permutedIdxToExpandedIdx,
+    int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert,
+    int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas, btg::Dtype dtypeElt,
+    bool useRoutingScalesOnInput, bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream)
 {
     if (routingMethodType == RoutingMethodType::DeepSeekV3)
     {
@@ -84,6 +84,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mPtrExpertCounts = expertCountHistogram;
         routingData.mPtrPermutedIdxSize = permutedIdxSize;
         routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+        routingData.mPtrExpandedIdxToExpertIdx = expandedIdxToExpertIdx;
         routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
         routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
         routingData.mPtrTopKWeights = expertWeights;
@@ -127,6 +128,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mPtrExpertCounts = expertCountHistogram;
         routingData.mPtrPermutedIdxSize = permutedIdxSize;
         routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+        routingData.mPtrExpandedIdxToExpertIdx = expandedIdxToExpertIdx;
         routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
         routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
         routingData.mPtrTopKWeights = expertWeights;
@@ -183,6 +185,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mPtrExpertCounts = expertCountHistogram;
         routingData.mPtrPermutedIdxSize = permutedIdxSize;
         routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
+        routingData.mPtrExpandedIdxToExpertIdx = expandedIdxToExpertIdx;
         routingData.mPtrPermutedIdxToExpandedIdx = permutedIdxToExpandedIdx;
         routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
         routingData.mPtrTopKWeights = expertWeights;
@@ -522,8 +525,8 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
             finalizeData.expertWeightsPtr = workspace.expert_weights;
         }
         finalizeData.expandedIdxToPermutedIdx = workspace.expanded_idx_to_permuted_idx;
-        finalizeData.expertIndexes = args.topk_ids != nullptr ? args.topk_ids : workspace.routing_expert_indexes;
-        finalizeData.expertIndexesArePacked = args.topk_ids == nullptr;
+        finalizeData.expertIndexes = args.topk_ids != nullptr ? args.topk_ids : workspace.expanded_idx_to_expert_idx;
+        finalizeData.expertIndexesArePacked = false;
         finalizeData.numTokens = args.num_tokens;
         finalizeData.numExperts = args.num_experts;
         finalizeData.topK = args.top_k;
@@ -729,8 +732,9 @@ void Runner::run(
         printDeviceFloats("hidden_states_scale (input)", static_cast<float const*>(hidden_states_scale_linear), 16, stream);
         printDeviceFloats("finalize_input_scale (input)", args.finalize_input_scale, 16, stream);
         printDeviceInts("topk_ids (input)", args.topk_ids, 16, stream);
+        printDeviceInts("expanded_idx_to_expert_idx (after routing)", workspace.expanded_idx_to_expert_idx, 16, stream);
         printPackedRoutingExpertIds(
-            "routing_expert_indexes packed (after routing)", workspace.routing_expert_indexes, 16, stream);
+            "routing_expert_indexes packed scratch (after routing)", workspace.routing_expert_indexes, 16, stream);
     }
 
     mPermuteGemm1.run(args.hidden_states, hidden_states_scale_linear, args.gemm1_weights, args.gemm1_weights_scale,
@@ -786,7 +790,8 @@ void Runner::run(
     if (args.do_finalize)
     {
         // Run finalize
-        TLLM_CHECK_WITH_INFO(args.finalize_input_scale == nullptr || workspace.routing_expert_indexes != nullptr,
+        TLLM_CHECK_WITH_INFO(args.finalize_input_scale == nullptr
+                || args.topk_ids != nullptr || workspace.expanded_idx_to_expert_idx != nullptr,
             "Finalize input scale factors require routing expert indexes.");
         moe::dev::finalize::run(finalizeData, stream);
         sync_check_cuda_error(stream);

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
@@ -311,6 +311,10 @@ struct MoERunnerArgs
     float* output1_scales_gate_scalar = nullptr;
     float* output2_scales_scalar = nullptr;
 
+    // Optional per-expert factors applied inside the finalize kernel.
+    // input: [num_experts, hidden_size].
+    float* finalize_input_scale = nullptr;
+
     // Output:
     void* output = nullptr;
     float* output_scale = nullptr;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
@@ -162,11 +162,11 @@ public:
     void run(void* routingLogits, void* routingBias, int32_t numTokens, int32_t numExperts, int32_t topK,
         int32_t nGroups, int32_t topkGroups, int32_t localExpertOffset, int32_t localNumExperts,
         float routedScalingFactor, int32_t* routingExpertIndexes, int32_t* expertCountHistogram,
-        int32_t* permutedIdxSize, int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx,
-        int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert,
-        int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas,
-        batchedGemm::trtllm::gen::Dtype dtypeElt, bool useRoutingScalesOnInput, bool useDeepSeekFp8,
-        RoutingMethodType routingMethodType, cudaStream_t stream);
+        int32_t* permutedIdxSize, int32_t* expandedIdxToPermutedIdx, int32_t* expandedIdxToExpertIdx,
+        int32_t* permutedIdxToExpandedIdx, int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* expertIds,
+        int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit,
+        int32_t* numNonExitingCtas, batchedGemm::trtllm::gen::Dtype dtypeElt, bool useRoutingScalesOnInput,
+        bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream);
 
 private:
     int32_t mTileTokensDim;
@@ -332,6 +332,7 @@ struct MoEWorkspace
     int32_t total_max_padded_tokens{0};
 
     int32_t* expanded_idx_to_permuted_idx = nullptr;
+    int32_t* expanded_idx_to_expert_idx = nullptr;
     int32_t* permuted_idx_to_expanded_idx = nullptr;
     int32_t* permuted_idx_to_token_idx = nullptr;
     void* expert_weights = nullptr; // [num_tokens, top_k] in bfloat16 = mDtypeExpW

--- a/cpp/tensorrt_llm/thop/cuteDslMoeUtilsOp.cpp
+++ b/cpp/tensorrt_llm/thop/cuteDslMoeUtilsOp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ std::vector<torch::Tensor> moe_topk_sort_impl(torch::optional<torch::Tensor> con
     routing_runner.run(routing_logits_ptr, routing_bias_ptr, num_tokens, num_experts, top_k, n_group.value_or(0),
         topk_group.value_or(0), local_expert_offset, local_num_experts, routed_scaling_factor.value_or(1.0),
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
-        expanded_idx_to_permuted_idx.data_ptr<int>(), permuted_idx_to_expanded_idx.data_ptr<int>(),
+        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, permuted_idx_to_expanded_idx.data_ptr<int>(),
         nullptr /*permuted_idx_to_token_idx.data_ptr<int>()*/, token_final_scales_ptr, token_selected_experts_ptr,
         num_tokens_per_expert.data_ptr<int>(), tile_idx_to_expert_idx.data_ptr<int>(),
         tile_idx_to_mn_limit.data_ptr<int>(), num_non_exiting_tiles.data_ptr<int>(),

--- a/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
@@ -267,8 +267,9 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
-        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, nullptr,
+        /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/ permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr,
+        args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
         cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
         false /* use_routing_scales_on_input */, false /* use_deep_seek_fp8 */,

--- a/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
@@ -235,8 +235,9 @@ at::Tensor run_fp8_block_scale_moe(at::optional<at::Tensor> const& routing_logit
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
-        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/,
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr,
+        nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/, permuted_idx_to_token_idx.data_ptr<int>(),
+        expert_weights_ptr, args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
         cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt, false, true,
         static_cast<RoutingMethodType>(routing_method_type), stream);

--- a/cpp/tensorrt_llm/thop/fp8PerTensorScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8PerTensorScaleMoe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,8 +233,9 @@ torch::Tensor fp8_per_tensor_scale_moe_runner(torch::optional<torch::Tensor> con
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
-        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/,
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr,
+        nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/, permuted_idx_to_token_idx.data_ptr<int>(),
+        expert_weights_ptr, args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
         cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
         use_routing_scales_on_input, false /* use_deep_seek_fp8 */, static_cast<RoutingMethodType>(routing_method_type),

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -222,6 +222,8 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
         = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::BFloat16, routing_device, std::nullopt);
     at::Tensor expert_indexes
         = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expanded_idx_to_expert_idx
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
 
     int64_t const size_of_expert_count_histogram = std::max(num_experts * 2, int64_t(256 * 2));
     at::Tensor expert_count_histogram
@@ -279,8 +281,9 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
-        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        expanded_idx_to_permuted_idx.data_ptr<int>(), expanded_idx_to_expert_idx.data_ptr<int>(), nullptr,
+        /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/ permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr,
+        args.topk_ids,
         num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
         cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
         false /* use_routing_scales_on_input */, false /* use_deep_seek_fp8 */,
@@ -462,6 +465,7 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
     workspace.permuted_idx_size = total_num_padded_tokens.data_ptr<int>();
     workspace.expanded_idx_to_permuted_idx
         = expanded_idx_to_permuted_idx.data_ptr<int>(); // Needed by permute/finalize kernels
+    workspace.expanded_idx_to_expert_idx = expanded_idx_to_expert_idx.data_ptr<int>();
     workspace.permuted_idx_to_token_idx = permuted_idx_to_token_idx.data_ptr<int>(); // Needed by permuteGemm1 kernel
     workspace.expert_weights = expert_weights_ptr;                                   // Consumed by finalize kernel
 

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -50,7 +50,7 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
     std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim, int64_t const routing_method_type,
     btg::Dtype const dtype, MoeRunnerType& moe_runner, int64_t moeConfigIndex,
     torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids,
-    torch::optional<torch::Tensor> const& out_tensor)
+    torch::optional<torch::Tensor> const& out_tensor, torch::optional<torch::Tensor> const& finalize_input_scale)
 {
     TORCH_CHECK(tensorrt_llm::common::isSM100Family(), "Only SM100f is supported by MXFP4 block scale MOE");
     TORCH_CHECK(tile_tokens_dim == 8 || tile_tokens_dim == 16 || tile_tokens_dim == 32 || tile_tokens_dim == 64
@@ -173,6 +173,8 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
         = output1_scale_gate_scalar.has_value() ? output1_scale_gate_scalar.value().data_ptr<float>() : nullptr;
     args.output2_scales_scalar
         = output2_scale_scalar.has_value() ? output2_scale_scalar.value().data_ptr<float>() : nullptr;
+    args.finalize_input_scale
+        = finalize_input_scale.has_value() ? finalize_input_scale.value().data_ptr<float>() : nullptr;
     args.num_tokens = hidden_states.sizes()[0];
     args.num_experts = num_experts;
     // Hidden dimension input of MoE block. It might be padded.
@@ -421,6 +423,19 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
             output2_scale_scalar->sizes()[0] == local_num_experts, "output2_scales_scalar has incorrect dim 0.");
     }
 
+    if (finalize_input_scale.has_value())
+    {
+        TORCH_CHECK(finalize_input_scale->scalar_type() == at::ScalarType::Float,
+            "finalize_input_scale must be float, got %s.", c10::toString(finalize_input_scale->scalar_type()));
+        TORCH_CHECK(finalize_input_scale->dim() == 2, "finalize_input_scale must be 2D.");
+        TORCH_CHECK(finalize_input_scale->sizes()[0] == num_experts, "finalize_input_scale has incorrect dim 0.");
+        TORCH_CHECK(finalize_input_scale->sizes()[1] == args.valid_hidden_size.value_or(args.hidden_size),
+            "finalize_input_scale has incorrect dim 1.");
+        TORCH_CHECK(finalize_input_scale->device() == hidden_states.device(),
+            "finalize_input_scale must be on the input device.");
+        TORCH_CHECK(finalize_input_scale->is_contiguous(), "finalize_input_scale must be contiguous.");
+    }
+
     // allocate or use provided output
     at::Tensor output;
     if (out_tensor.has_value())
@@ -531,7 +546,8 @@ public:
         int64_t local_expert_offset, int64_t local_num_experts, std::optional<double> routed_scaling_factor,
         int64_t routing_method_type, std::vector<int64_t> moeConfigIndex,
         torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids,
-        torch::optional<torch::Tensor> const& output = torch::nullopt)
+        torch::optional<torch::Tensor> const& output = torch::nullopt,
+        torch::optional<torch::Tensor> const& finalize_input_scale = torch::nullopt)
 
     {
         // moeConfigIndex corresponds to pair (tileN, config)
@@ -556,7 +572,7 @@ public:
             gemm2_weights_scale, gemm2_bias, std::nullopt, std::nullopt, std::nullopt, num_experts, top_k, n_group,
             topk_group, intermediate_size, valid_hidden_size, valid_intermediate_size, local_expert_offset,
             local_num_experts, routed_scaling_factor, tileN, routing_method_type, mDtypeAct, *mRunners[tileN], config,
-            topk_weights, topk_ids, output);
+            topk_weights, topk_ids, output, finalize_input_scale);
     }
 
 private:
@@ -626,7 +642,8 @@ public:
         int64_t local_expert_offset, int64_t local_num_experts, std::optional<double> routed_scaling_factor,
         int64_t routing_method_type, std::vector<int64_t> tile_config_pair,
         torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids,
-        torch::optional<torch::Tensor> const& output)
+        torch::optional<torch::Tensor> const& output,
+        torch::optional<torch::Tensor> const& finalize_input_scale = torch::nullopt)
     {
         // tile_config_pair corresponds to pair (tileN, config)
         auto [tileN, config] = std::tie(tile_config_pair[0], tile_config_pair[1]);
@@ -650,7 +667,7 @@ public:
             gemm2_weights_scale, gemm2_bias, output1_scale_scalar, output1_scale_gate_scalar, output2_scale_scalar,
             num_experts, top_k, n_group, topk_group, intermediate_size, valid_hidden_size, valid_intermediate_size,
             local_expert_offset, local_num_experts, routed_scaling_factor, tileN, routing_method_type, mDtypeAct,
-            *mRunners[tileN], config, topk_weights, topk_ids, output);
+            *mRunners[tileN], config, topk_weights, topk_ids, output, finalize_input_scale);
     }
 
     /**


### PR DESCRIPTION
Add an optional per-expert element-wise scale factor into the finalize kernel of blockScaleMoe
