### PR TITLE
disable pdl for the A2ACombineKernel

### DIFF
--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -575,6 +575,12 @@ int getEnvMoeA2ACombineBlockSize()
     return kBlock;
 }
 
+bool getEnvDisablePdlMoeCombine()
+{
+    static bool const disablePdlMoeCombine = getBoolEnv("TLLM_DISABLE_PDL_MOE_COMBINE");
+    return disablePdlMoeCombine;
+}
+
 bool getEnvEplbForceGdrcopy()
 {
     return getBoolEnv("TRTLLM_EPLB_FORCE_GDRCOPY");

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -164,6 +164,9 @@ int getEnvMoeA2ADispatchBlockSize();
 // Block size (threads per block) for MoE A2A Combine kernels (default 256 if unset or invalid)
 int getEnvMoeA2ACombineBlockSize();
 
+// Whether PDL is disabled for the MoE A2A Combine kernel (default false).
+bool getEnvDisablePdlMoeCombine();
+
 bool getEnvKVCacheTransferAllBlocksForWindow();
 
 bool getEnvEplbForceGdrcopy();

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -1135,7 +1135,7 @@ __global__ void moeA2APrepareCombineKernel(uint8_t* recv_buffer_bytes, void cons
 // Generic Combine Kernel Implementation (Templated by data type)
 // ============================================================================
 
-template <typename T, typename ThreadingPolicy, int TOP_K>
+template <typename T, typename ThreadingPolicy, int TOP_K, bool ENABLE_PDL>
 __global__ void moeA2ACombineKernel(
     const CombineKernelPointers ptrs, // Combine-specific struct, src_data_ptrs[0] is output
     int max_tokens_per_rank, int elements_per_token, int local_num_tokens, int rank_id, int ep_size,
@@ -1158,6 +1158,13 @@ __global__ void moeA2ACombineKernel(
         if (local_token_idx >= local_num_tokens)
             return;
     }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    if constexpr (ENABLE_PDL)
+    {
+        cudaGridDependencySynchronize();
+    }
+#endif
 
 #if !DISABLE_SYNC_FOR_PROFILING
     // In-kernel readiness synchronization at start of combine:
@@ -1242,6 +1249,12 @@ __global__ void moeA2ACombineKernel(
         vectorized_combine<TOP_K, ThreadingPolicy, T>(
             token_output, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    if constexpr (ENABLE_PDL)
+    {
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
+#endif
 }
 
 void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params)
@@ -1347,14 +1360,28 @@ void moe_a2a_combine_launch(MoeA2ACombineParams const& params)
     // so dispatch the FP8 accumulation kernel in that case.
     auto const effective_dtype = params.use_low_precision ? nvinfer1::DataType::kFP8 : params.dtype;
 
+    bool const enablePDL
+        = tensorrt_llm::common::getEnvEnablePDL() && !tensorrt_llm::common::getEnvDisablePdlMoeCombine();
+
     // Launch appropriate kernel with compact macros
     SWITCH_DTYPE(effective_dtype, TKernelType, {
         SWITCH_POLICY(params.one_block_per_token, Policy, {
             SWITCH_TOP_K(params.top_k, TOP_K, {
-                auto kernel_fn = moeA2ACombineKernel<TKernelType, Policy, TOP_K>;
-                kernel_fn<<<grid, kBlockSize, 0, params.stream>>>(kernel_ptrs, params.max_tokens_per_rank,
-                    params.elements_per_token, params.local_num_tokens, params.ep_rank, params.ep_size,
-                    stride_per_token);
+                if (enablePDL)
+                {
+                    auto kernel_fn = moeA2ACombineKernel<TKernelType, Policy, TOP_K, true>;
+                    launchWithPdlWhenEnabled("moeA2ACombineKernel", kernel_fn, grid, kBlockSize, 0, params.stream,
+                        kernel_ptrs, params.max_tokens_per_rank, params.elements_per_token, params.local_num_tokens,
+                        params.ep_rank, params.ep_size, stride_per_token);
+                }
+                else
+                {
+                    auto kernel_fn = moeA2ACombineKernel<TKernelType, Policy, TOP_K, false>;
+                    kernel_fn<<<grid, kBlockSize, 0, params.stream>>>(kernel_ptrs, params.max_tokens_per_rank,
+                        params.elements_per_token, params.local_num_tokens, params.ep_rank, params.ep_size,
+                        stride_per_token);
+                    TLLM_CUDA_CHECK(cudaGetLastError());
+                }
             });
         });
     });

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -1159,10 +1159,6 @@ __global__ void moeA2ACombineKernel(
             return;
     }
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    cudaGridDependencySynchronize();
-#endif
-
 #if !DISABLE_SYNC_FOR_PROFILING
     // In-kernel readiness synchronization at start of combine:
     // - One warp signals readiness to all peers with current flag_val.
@@ -1246,9 +1242,6 @@ __global__ void moeA2ACombineKernel(
         vectorized_combine<TOP_K, ThreadingPolicy, T>(
             token_output, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    cudaTriggerProgrammaticLaunchCompletion();
-#endif
 }
 
 void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params)
@@ -1359,9 +1352,9 @@ void moe_a2a_combine_launch(MoeA2ACombineParams const& params)
         SWITCH_POLICY(params.one_block_per_token, Policy, {
             SWITCH_TOP_K(params.top_k, TOP_K, {
                 auto kernel_fn = moeA2ACombineKernel<TKernelType, Policy, TOP_K>;
-                launchWithPdlWhenEnabled("moeA2ACombineKernel", kernel_fn, grid, kBlockSize, 0, params.stream,
-                    kernel_ptrs, params.max_tokens_per_rank, params.elements_per_token, params.local_num_tokens,
-                    params.ep_rank, params.ep_size, stride_per_token);
+                kernel_fn<<<grid, kBlockSize, 0, params.stream>>>(kernel_ptrs, params.max_tokens_per_rank,
+                    params.elements_per_token, params.local_num_tokens, params.ep_rank, params.ep_size,
+                    stride_per_token);
             });
         });
     });


### PR DESCRIPTION
Disables PDL for `moeA2ACombineKernel`
This is a workaround to unblock `nsys` profiling in EP>1 configs of `gpt-oss` models family.

Profiling of EP>1 configurations with `nsys` crashes with illegal memory access. The root cause of the crashes was not found yet.

It's empirically tested that it's sufficient to disable PDL for the moeA2ACombineKernel, to make `nsys` profiling work without crashes.

Current fix might mildly impact the performance.